### PR TITLE
Fix code scanning alert #6: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
@@ -302,7 +302,7 @@ public class BackupManagerTest {
 
     // an invalid signature
     final byte[] wrongSignature = Arrays.copyOf(signature, signature.length);
-    wrongSignature[1] += 1;
+    wrongSignature[1] = (byte) (wrongSignature[1] + 1);
 
     // shouldn't be able to set a public key with an invalid signature
     assertThatExceptionOfType(StatusRuntimeException.class)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/6](https://github.com/offsoc/Signal-Server/security/code-scanning/6)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
