### PR TITLE
Fix code scanning alert no. 2: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerTest.java
@@ -70,7 +70,7 @@ class AttachmentControllerTest {
   static {
     try {
       final KeyPairGenerator  keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-      keyPairGenerator.initialize(1024);
+      keyPairGenerator.initialize(2048);
       final KeyPair           keyPair          = keyPairGenerator.generateKeyPair();
 
       RSA_PRIVATE_KEY_PEM = "-----BEGIN PRIVATE KEY-----\n" +


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/2](https://github.com/offsoc/Signal-Server/security/code-scanning/2)

To fix the problem, we need to increase the key size used in the RSA key pair generation from 1024 bits to 2048 bits. This change ensures that the key size meets the recommended security standards for RSA encryption. The modification will be made in the static block where the `KeyPairGenerator` is initialized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
