### PR TITLE
Fix code scanning alert no. 4: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/auth/TurnTokenGenerator.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/auth/TurnTokenGenerator.java
@@ -31,7 +31,7 @@ public class TurnTokenGenerator {
 
   private final byte[] turnSecret;
 
-  private static final String ALGORITHM = "HmacSHA1";
+  private static final String ALGORITHM = "HmacSHA256";
 
   private static final String WithUrlsProtocol = "00";
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/4](https://github.com/offsoc/Signal-Server/security/code-scanning/4)

To fix the problem, we need to replace the weak HmacSHA1 algorithm with a stronger one, such as HmacSHA256. This change will enhance the security of the cryptographic operations without altering the existing functionality.

1. **General Fix**: Replace the usage of HmacSHA1 with HmacSHA256.
2. **Detailed Fix**: Update the `ALGORITHM` constant to use "HmacSHA256" and ensure that the rest of the code remains compatible with this change.
3. **Specific Changes**:
   - Update the `ALGORITHM` constant definition.
   - Ensure that the `Mac` instance is created using the new algorithm.
   - Verify that the rest of the code does not require any additional changes to accommodate the new algorithm.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
