### PR TITLE
Fix code scanning alert no. 5: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/RemoteConfigController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/RemoteConfigController.java
@@ -54,7 +54,7 @@ public class RemoteConfigController {
   @Produces(MediaType.APPLICATION_JSON)
   public UserRemoteConfigList getAll(@ReadOnly @Auth AuthenticatedDevice auth) {
     try {
-      MessageDigest digest = MessageDigest.getInstance("SHA1");
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
       final Stream<UserRemoteConfig> globalConfigStream = globalConfig.entrySet().stream()
           .map(entry -> new UserRemoteConfig(GLOBAL_CONFIG_PREFIX + entry.getKey(), true, entry.getValue()));


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/5](https://github.com/offsoc/Signal-Server/security/code-scanning/5)

To fix the problem, we should replace the use of the SHA-1 algorithm with a stronger, modern cryptographic algorithm such as SHA-256. This change will enhance the security of the hashing process by making it resistant to collision attacks.

- **General Fix:** Replace `MessageDigest.getInstance("SHA1")` with `MessageDigest.getInstance("SHA-256")`.
- **Detailed Fix:** Update the instantiation of the `MessageDigest` object on line 57 to use "SHA-256" instead of "SHA1".
- **Files/Regions/Lines to Change:** The change will be made in the file `service/src/main/java/org/whispersystems/textsecuregcm/controllers/RemoteConfigController.java` on line 57.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
