### PR TITLE
Fix code scanning alert no. 6: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
@@ -302,7 +302,7 @@ public class BackupManagerTest {
 
     // an invalid signature
     final byte[] wrongSignature = Arrays.copyOf(signature, signature.length);
-    wrongSignature[1] += 1;
+    wrongSignature[1] = (byte) (wrongSignature[1] + 1);
 
     // shouldn't be able to set a public key with an invalid signature
     assertThatExceptionOfType(StatusRuntimeException.class)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/6](https://github.com/offsoc/Signal-Server/security/code-scanning/6)

To fix the problem, we need to ensure that the addition operation does not result in an implicit narrowing conversion. This can be achieved by explicitly casting the result of the addition back to a `byte` after performing the operation in a wider type (`int`). This way, we avoid any unintended data loss or overflow.

- Change the compound assignment `wrongSignature[1] += 1` to a simple addition followed by an explicit cast to `byte`.
- This change should be made in the `signatureValidation` method in the `BackupManagerTest` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
