### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
@@ -302,7 +302,7 @@ public class BackupManagerTest {
 
     // an invalid signature
     final byte[] wrongSignature = Arrays.copyOf(signature, signature.length);
-    wrongSignature[1] += 1;
+    wrongSignature[1] = (byte) (wrongSignature[1] + 1);
 
     // shouldn't be able to set a public key with an invalid signature
     assertThatExceptionOfType(StatusRuntimeException.class)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/1](https://github.com/offsoc/Signal-Server/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we can achieve this by explicitly casting the result of the addition to `byte` before assigning it back to the array element. This will prevent any implicit narrowing conversion and make the code's intent clear.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
