### PR TITLE
Fix code scanning alert no. 4: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/auth/TurnTokenGenerator.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/auth/TurnTokenGenerator.java
@@ -31,7 +31,7 @@ public class TurnTokenGenerator {
 
   private final byte[] turnSecret;
 
-  private static final String ALGORITHM = "HmacSHA1";
+  private static final String ALGORITHM = "HmacSHA256";
 
   private static final String WithUrlsProtocol = "00";
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/4](https://github.com/offsoc/Signal-Server/security/code-scanning/4)

To fix the problem, we need to replace the weak HmacSHA1 algorithm with a stronger one, such as HmacSHA256. This change involves updating the algorithm constant and ensuring that the rest of the code remains compatible with the new algorithm. Specifically, we will:
1. Change the `ALGORITHM` constant from "HmacSHA1" to "HmacSHA256".
2. Ensure that the `Mac` instance and `SecretKeySpec` initialization use the updated algorithm.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
