### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
@@ -383,7 +383,7 @@ public class BackupManagerTest {
 
     // an invalid signature
     final byte[] wrongSignature = Arrays.copyOf(signature, signature.length);
-    wrongSignature[1] += 1;
+    wrongSignature[1] = (byte) (wrongSignature[1] + 1);
 
     // shouldn't be able to set a public key with an invalid signature
     assertThatExceptionOfType(StatusRuntimeException.class)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/1](https://github.com/offsoc/Signal-Server/security/code-scanning/1)

To fix the problem, we need to ensure that the addition operation does not result in an implicit narrowing conversion. We can achieve this by explicitly casting the result of the addition back to `byte` after performing the operation in the `int` type. This way, we avoid any unintended overflow or information loss.

The best way to fix the problem is to change the line `wrongSignature[1] += 1;` to `wrongSignature[1] = (byte) (wrongSignature[1] + 1);`. This ensures that the addition is performed in the `int` type, and the result is explicitly cast back to `byte`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
