### PR TITLE
Fix code scanning alert no. 5: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/RemoteConfigController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/RemoteConfigController.java
@@ -54,7 +54,7 @@ public class RemoteConfigController {
   @Produces(MediaType.APPLICATION_JSON)
   public UserRemoteConfigList getAll(@ReadOnly @Auth AuthenticatedDevice auth) {
     try {
-      MessageDigest digest = MessageDigest.getInstance("SHA1");
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
       final Stream<UserRemoteConfig> globalConfigStream = globalConfig.entrySet().stream()
           .map(entry -> new UserRemoteConfig(GLOBAL_CONFIG_PREFIX + entry.getKey(), true, entry.getValue()));


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/5](https://github.com/offsoc/Signal-Server/security/code-scanning/5)

To fix the problem, we need to replace the use of the SHA-1 algorithm with a stronger, modern cryptographic algorithm such as SHA-256. This involves changing the `MessageDigest.getInstance("SHA1")` call to `MessageDigest.getInstance("SHA-256")`. This change ensures that the hashing mechanism is more secure and resistant to collision attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
