### PR TITLE
Fix code scanning alert no. 3: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/service/src/main/java/org/whispersystems/textsecuregcm/auth/SaltedTokenHash.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/auth/SaltedTokenHash.java
@@ -58,7 +58,7 @@ public record SaltedTokenHash(String hash, String salt) {
   private static String calculateV1Hash(final String salt, final String token) {
     try {
       return HexFormat.of()
-          .formatHex(MessageDigest.getInstance("SHA1").digest((salt + token).getBytes(StandardCharsets.UTF_8)));
+          .formatHex(MessageDigest.getInstance("SHA-256").digest((salt + token).getBytes(StandardCharsets.UTF_8)));
     } catch (final NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/3](https://github.com/offsoc/Signal-Server/security/code-scanning/3)

To fix the problem, we need to replace the use of the SHA-1 algorithm with a stronger, modern cryptographic algorithm. A good choice would be SHA-256, which is part of the SHA-2 family and is considered secure for most applications.

- Replace the `MessageDigest.getInstance("SHA1")` call with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code correctly handles the output of SHA-256, which is longer than SHA-1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
