### PR TITLE
Fix code scanning alert no. 2: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV4Test.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV4Test.java
@@ -70,7 +70,7 @@ class AttachmentControllerV4Test {
   static {
     try {
       final KeyPairGenerator  keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-      keyPairGenerator.initialize(1024);
+      keyPairGenerator.initialize(2048);
       final KeyPair           keyPair          = keyPairGenerator.generateKeyPair();
 
       RSA_PRIVATE_KEY_PEM = "-----BEGIN PRIVATE KEY-----\n" +


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/2](https://github.com/offsoc/Signal-Server/security/code-scanning/2)

To fix the problem, we need to increase the key size to at least 2048 bits for the RSA key pair generation. This change ensures that the key size meets the recommended security standards and reduces the risk of brute force attacks.

The best way to fix the problem without changing existing functionality is to modify the key size parameter in the `initialize` method of the `KeyPairGenerator` instance. Specifically, we need to change the key size from 1024 to 2048 bits.

The required changes are in the file `service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV4Test.java` on line 73.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
