### PR TITLE
Fix code scanning alert no. 9: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/backup/BackupManagerTest.java
@@ -383,7 +383,7 @@ public class BackupManagerTest {
 
     // an invalid signature
     final byte[] wrongSignature = Arrays.copyOf(signature, signature.length);
-    wrongSignature[1] += 1;
+    wrongSignature[1] = (byte) (wrongSignature[1] + 1);
 
     // shouldn't be able to set a public key with an invalid signature
     assertThatExceptionOfType(StatusRuntimeException.class)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/9](https://github.com/offsoc/Signal-Server/security/code-scanning/9)

To fix the problem, we need to ensure that the addition operation does not result in an implicit narrowing conversion. This can be achieved by explicitly casting the result of the addition back to `byte` after performing the addition in a wider type (e.g., `int`). This way, we can control the conversion and ensure it is safe.

The best way to fix this is to perform the addition in an `int` context and then cast the result back to `byte`. This ensures that the addition is done correctly without overflow, and the result is safely converted back to `byte`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
