### PR TITLE
Fix code scanning alert no. 10: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV4Test.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AttachmentControllerV4Test.java
@@ -70,7 +70,7 @@ class AttachmentControllerV4Test {
   static {
     try {
       final KeyPairGenerator  keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-      keyPairGenerator.initialize(1024);
+      keyPairGenerator.initialize(2048);
       final KeyPair           keyPair          = keyPairGenerator.generateKeyPair();
 
       RSA_PRIVATE_KEY_PEM = "-----BEGIN PRIVATE KEY-----\n" +


### PR DESCRIPTION
Fixes [https://github.com/offsoc/Signal-Server/security/code-scanning/10](https://github.com/offsoc/Signal-Server/security/code-scanning/10)

To fix the problem, we need to increase the key size used in the RSA key pair generation to at least 2048 bits. This change will ensure that the key size meets the recommended minimum for RSA encryption, thereby enhancing the security of the system.

The specific change involves updating the `initialize` method call on the `KeyPairGenerator` instance to use a key size of 2048 bits instead of 1024 bits. This change should be made in the static block where the RSA key pair is generated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
