### PR TITLE
Potential fix for code scanning alert no. 20: Implicit narrowing conversion in compound assignment

### DIFF
--- a/service/src/test/java/org/whispersystems/textsecuregcm/grpc/MessagesAnonymousGrpcServiceTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/grpc/MessagesAnonymousGrpcServiceTest.java
@@ -282,7 +282,7 @@ class MessagesAnonymousGrpcServiceTest extends
       incorrectUnidentifiedAccessKey[0] += 1;
 
       final byte[] incorrectGroupSendToken = GROUP_SEND_TOKEN.clone();
-      incorrectGroupSendToken[0] += 1;
+      incorrectGroupSendToken[0] = (byte) (incorrectGroupSendToken[0] + 1);
 
       //noinspection ResultOfMethodCallIgnored
       GrpcTestUtils.assertStatusException(Status.UNAUTHENTICATED,


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/Signal-Server/security/code-scanning/20](https://github.com/offsoc/Signal-Server/security/code-scanning/20)

To fix the implicit narrowing conversion, we should make the cast explicit. Instead of using `incorrectGroupSendToken[0] += 1;`, we should write `incorrectGroupSendToken[0] = (byte) (incorrectGroupSendToken[0] + 1);`. This makes it clear that we are intentionally converting the result of the addition (an `int`) back to a `byte`, and avoids the implicit narrowing conversion in the compound assignment. Only line 285 in `service/src/test/java/org/whispersystems/textsecuregcm/grpc/MessagesAnonymousGrpcServiceTest.java` needs to be changed. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
